### PR TITLE
 added library.json for compatibility with platformIO (reorganized)

### DIFF
--- a/Arduino/src/ArCOM.cpp
+++ b/Arduino/src/ArCOM.cpp
@@ -132,7 +132,7 @@ void ArCOM::writeCharArray(char charArray[], unsigned int nValues) {
   ArCOMstream->write(charArray, nValues);
 }
 void ArCOM::writeInt8Array(int8_t numArray[], unsigned int nValues) {
-  for (int i = 0; i < nValues; i++) {
+  for (unsigned int i = 0; i < nValues; i++) {
     typeBuffer.int8 = numArray[i];
     ArCOMstream->write(typeBuffer.byteArray[0]);
   }
@@ -144,7 +144,7 @@ void ArCOM::writeUint16Array(uint16_t numArray[], unsigned int nValues) {
   }
 }
 void ArCOM::writeInt16Array(int16_t numArray[], unsigned int nValues) {
-  for (int i = 0; i < nValues; i++) {
+  for (unsigned int i = 0; i < nValues; i++) {
     typeBuffer.int16 = numArray[i];
     ArCOMstream->write(typeBuffer.byteArray, 2);
   }

--- a/library.json
+++ b/library.json
@@ -9,6 +9,7 @@
       "url": "https://github.com/sanworks/ArCOM.git"
     },
     "srcDir": "Arduino/src",
+    "includeDir": "Arduino/src",
     "authors":
     [
       {

--- a/library.json
+++ b/library.json
@@ -1,0 +1,22 @@
+{
+    "name": "ArCOM",
+    "version": "1.0.0",
+    "description": "An interface to simplify data transactions between Arduino and MATLAB/GNU Octave",
+    "keywords": "ArCOM, Bpod, Arduino, MATLAB, Octave, Python",
+    "repository":
+    {
+      "type": "git",
+      "url": "https://github.com/sanworks/ArCOM.git"
+    },
+    "srcDir": "Arduino/src",
+    "authors":
+    [
+      {
+        "name": "Josh Sanders",
+        "url": "https://www.sanworks.io"
+      }
+    ],
+    "license": "GPLv3",
+    "frameworks": "*",
+    "platforms": "*"
+  }

--- a/library.json
+++ b/library.json
@@ -8,8 +8,9 @@
       "type": "git",
       "url": "https://github.com/sanworks/ArCOM.git"
     },
-    "srcDir": "Arduino/src",
-    "includeDir": "Arduino/src",
+    "build": {
+        "srcDir": "Arduino/src"
+    },
     "authors":
     [
       {


### PR DESCRIPTION
[I recreated this PR as I had to move the sources from [bimac:master](https://github.com/bimac/ArCOM) to [bimac:feat/pio](https://github.com/bimac/ArCOM/tree/feat/pio). The original PR can be found here: #1]

Hi Josh,

here's a small PR making ArCOM compatible with platformIO. See [the PIO docs](https://docs.platformio.org/en/latest/librarymanager/config.html#) for more information regarding the contents of library.json. I wasn't sure about the version number - I just went ahead and picked 1.0.0 ...

Cheers,
Florian

PS: I also included a minor fix regarding the comparison between signed/unsigned integers to make some warnings go away